### PR TITLE
fix: Error Tracking

### DIFF
--- a/generate/main.go
+++ b/generate/main.go
@@ -55,7 +55,7 @@ func parseFileStructs(fileName string) ([]strct, error) {
 	}
 
 	fset := token.NewFileSet()
-	f, err := parser.ParseFile(fset, "", fsrc, parser.AllErrors)
+	f, err := parser.ParseFile(fset, fileName, fsrc, parser.AllErrors)
 	if err != nil {
 		return nil, err
 	}
@@ -78,10 +78,10 @@ func parseFileStructs(fileName string) ([]strct, error) {
 				if f.Tag != nil {
 					tag = transformXMLTag(f.Tag.Value)
 				}
-				typeStr := fsrc[f.Type.Pos()-1 : f.Type.End()-1]
+				typeStr := string(fsrc[f.Type.Pos()-1 : f.Type.End()-1])
 				strct.fields = append(strct.fields, field{
 					name:  f.Names[0].Name,
-					fType: string(typeStr),
+					fType: typeStr,
 					tag:   tag,
 				})
 			}
@@ -112,7 +112,7 @@ func generateFile(fileName string, structs []strct) error {
 		fmt.Fprint(output, "if s == nil {\n\treturn nil\n}\n")
 		fmt.Fprintf(output, "\tvar r %s\n", strct.name)
 		for _, field := range strct.fields {
-			if ignoreType(field.fType) {
+			if isIgnoreType(field.fType) {
 				fmt.Fprintf(output, "\tr.%s = s.%s\n", field.name, field.name)
 				continue
 			}
@@ -186,7 +186,7 @@ func transformFieldType(inType string) string {
 	return fType
 }
 
-func ignoreType(t string) bool {
+func isIgnoreType(t string) bool {
 	return slices.Contains(ignoreTypes, strings.TrimLeft(t, "*[]"))
 }
 

--- a/generate/main.go
+++ b/generate/main.go
@@ -120,13 +120,13 @@ func generateFile(fileName string, structs []strct) error {
 			if isPtr(field.fType) {
 				fmt.Fprintf(output, "\tr.%s = s.%s.Translate()\n", field.name, field.name)
 			} else if isSlicePtr(field.fType) {
-				fmt.Fprintf(output, "\tv%s := make(%s, 0)\n", field.name, field.fType)
+				fmt.Fprintf(output, "\tv%s := make(%s, 0, len(s.%s))\n", field.name, field.fType, field.name)
 				fmt.Fprintf(output, "\tfor _, v := range s.%s {\n", field.name)
 				fmt.Fprintf(output, "\t\tv%s = append(v%s, v.Translate())\n", field.name, field.name)
 				fmt.Fprint(output, "\t}\n")
 				fmt.Fprintf(output, "\tr.%s = v%s\n", field.name, field.name)
 			} else if isSlice(field.fType) {
-				fmt.Fprintf(output, "\tv%s := make(%s, 0)\n", field.name, field.fType)
+				fmt.Fprintf(output, "\tv%s := make(%s, 0, len(s.%s))\n", field.name, field.fType, field.name)
 				fmt.Fprintf(output, "\tfor _, v := range s.%s {\n", field.name)
 				fmt.Fprint(output, "\t\tx := v.Translate()\n")
 				fmt.Fprintf(output, "\t\tv%s = append(v%s, *x)\n", field.name, field.name)

--- a/gopodcast_test.go
+++ b/gopodcast_test.go
@@ -187,7 +187,10 @@ func TestWriteFeed_RequiredFieldsOnly(t *testing.T) {
 	}
 
 	buf := &bytes.Buffer{}
-	podcast.WriteFeedXML(buf)
+	err := podcast.WriteFeedXML(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	exp, err := os.ReadFile("testdata/test-feed-write-minimum.xml")
 	if err != nil {
@@ -286,7 +289,10 @@ func TestWriteFeed_AllFields(t *testing.T) {
 	}
 
 	buf := &bytes.Buffer{}
-	podcast.WriteFeedXML(buf)
+	err := podcast.WriteFeedXML(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	exp, err := os.ReadFile("testdata/test-feed-write-all.xml")
 	if err != nil {

--- a/gopodcast_xml_fix.go
+++ b/gopodcast_xml_fix.go
@@ -63,7 +63,7 @@ func (s *xmlFixPodcast) Translate() *Podcast {
 	r.Description = *vDescription
 	r.Link = s.Link
 	r.Language = s.Language
-	vITunesCategory := make([]ITunesCategory, 0)
+	vITunesCategory := make([]ITunesCategory, 0, len(s.ITunesCategory))
 	for _, v := range s.ITunesCategory {
 		x := v.Translate()
 		vITunesCategory = append(vITunesCategory, *x)
@@ -80,7 +80,7 @@ func (s *xmlFixPodcast) Translate() *Podcast {
 	r.PodcastFunding = s.PodcastFunding.Translate()
 	r.ITunesType = s.ITunesType
 	r.ITunesComplete = s.ITunesComplete
-	vItems := make([]*Item, 0)
+	vItems := make([]*Item, 0, len(s.Items))
 	for _, v := range s.Items {
 		vItems = append(vItems, v.Translate())
 	}
@@ -209,7 +209,7 @@ func (s *xmlFixItem) Translate() *Item {
 	r.ITunesDuration = s.ITunesDuration
 	r.ITunesImage = s.ITunesImage.Translate()
 	r.ITunesExplicit = s.ITunesExplicit
-	vPodcastTranscript := make([]PodcastTranscript, 0)
+	vPodcastTranscript := make([]PodcastTranscript, 0, len(s.PodcastTranscript))
 	for _, v := range s.PodcastTranscript {
 		x := v.Translate()
 		vPodcastTranscript = append(vPodcastTranscript, *x)

--- a/parser.go
+++ b/parser.go
@@ -28,7 +28,7 @@ func NewParser() *Parser {
 	}
 }
 
-func (p *Parser) ParseFeedFromURL(ctx context.Context, url string) (*Podcast, error) {
+func (p *Parser) ParseFeedFromURL(ctx context.Context, url string) (pc *Podcast, err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,12 @@ func (p *Parser) ParseFeedFromURL(ctx context.Context, url string) (*Podcast, er
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
+	defer func() {
+		errVal := res.Body.Close()
+		if errVal != nil {
+			err = errVal
+		}
+	}()
 
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		return nil, fmt.Errorf("non-200 http response '%d'", res.StatusCode)


### PR DESCRIPTION
- Added checks for `error` return values, where they were missing, especially within tests.
- Provided `fileName` to `parser.ParseFile` so that it can better provide error messages.
- Renamed `ignoreType` to `isIgnoreType` to better match others: i.e. `isPtr`, `isSlice`, `isSlicePtr`.
- Pre initialised the capacity of slices from generated code, where it is transforming an input slice.